### PR TITLE
HMRC variant of address finder

### DIFF
--- a/source/design-patterns/patterns/components/addresses/hmrc_address.html.md.erb
+++ b/source/design-patterns/patterns/components/addresses/hmrc_address.html.md.erb
@@ -1,0 +1,113 @@
+---
+title:		Addresses
+section:	Components
+status:		Approved
+discuss:	https://designpatterns.hackpad.com/CgrMSGRAhRc
+department: All
+---
+
+
+## Before you start
+
+The way you should ask for an address depends on what kind of address it is and what you need to do with it.
+
+This guide describes 3 ways to ask for addresses and when to use them.
+
+
+## Using a free text box
+
+Use a free text box if you expect a broad range of address formats and you don’t need to use specific sub-parts of the address (for example, street or postcode).
+
+Here’s an example:
+
+![Image of a free text address box](Address_1.png)
+
+
+### Advantages of a free text box
+
+A free text box:
+
+- can handle any possible address format
+- allows users to copy and paste addresses from their clipboard
+- means users don’t have to work out which part of the address goes in which field
+
+### Disadvantages of a free text box
+
+A free text box:
+
+- makes it hard for you to separate an address into sub-parts, and impossible to do with 100% accuracy
+- might not be compatible with legacy backend systems that use multi-field addresses
+- can’t help users look up an address
+
+
+## Using multiple fields
+
+Only use multiple address fields when you know which regions the addresses will come from and can find a format that supports them all. This can be difficult to know if you’re asking for addresses outside the UK.
+
+
+### Example of multiple fields
+
+Here’s an example of a multiple address field pattern that works for simple UK addresses:
+
+![Image of a multiple-field address box](Address_2.png)
+
+
+### Advantages of multiple fields
+
+Multiple fields mean:
+
+- you can easily extract and use specific parts of an address (for example, street names or postcodes)
+- you can give help for individual fields
+- you can validate each part of the address separately
+- users can complete the form using their browser’s auto-complete function
+
+
+### Disadvantages of multiple fields
+
+Multiple fields have these disadvantages:
+
+- it’s hard to find a single format that works for all addresses
+- there’s no guarantee that users will use the fields the way you think they will
+- users can’t easily paste addresses from their clipboard
+
+
+### If you use multiple fields
+
+When using multiple fields, you should:
+
+- avoid making individual fields mandatory (but warn users if they don’t fill in any fields)
+- make the fields the appropriate length for the content - it helps people understand the form (for example, make postcode fields shorter than street fields)
+- not make fields case sensitive (let people use upper or lower case)
+- write ‘postcode’ as one word
+- let people enter postcodes with or without spaces
+
+Royal Mail doesn’t need a county as long as the town and postcode are included, but you should include a county field so that people who don’t know their postcode can give a valid address.
+
+
+## Using an address finder
+
+An address finder (sometimes called a ‘postcode lookup’) lets users specify a UK address by entering their postcode (and optionally their street name or number) and selecting their address from a list.
+
+
+#### Example of an address finder
+
+Here’s how the Lasting Power of Attorney service used an address finder:
+
+![Image of a free text address box](postcode-lookup.gif)
+
+
+### Advantages of address finders
+
+Using an address finder means that:
+
+- people entering UK addresses don’t have to enter as much information manually
+- there’s less chance of mis-typed UK addresses
+
+
+### If you use an address finder
+
+When using an address finder you should:
+
+- make it clear that the address finder only works for UK addresses
+- provide a manual option for people with international addresses or addresses that are missing or badly formed in the Royal Mail database
+

--- a/source/design-patterns/patterns/components/addresses/hmrc_address.html.md.erb
+++ b/source/design-patterns/patterns/components/addresses/hmrc_address.html.md.erb
@@ -1,113 +1,47 @@
 ---
-title:		Addresses
-section:	Components
-status:		Approved
-discuss:	https://designpatterns.hackpad.com/CgrMSGRAhRc
-department: All
+title:      Address lookup
+section:    HMRC Components
+status:     Approved
+discuss:    https://designpatterns.hackpad.com/CgrMSGRAhRc
+department: HMRC
 ---
 
-
-## Before you start
-
-The way you should ask for an address depends on what kind of address it is and what you need to do with it.
-
-This guide describes 3 ways to ask for addresses and when to use them.
+**This is an HMRC pattern, you should only use this if the service you're designing is and HMRC service, or have the same database requirments as HMRC.**
 
 
-## Using a free text box
+## Using an address lookup
 
-Use a free text box if you expect a broad range of address formats and you don’t need to use specific sub-parts of the address (for example, street or postcode).
+<% partial "/layouts/example" do %>
+    <div class="form-group">
+        <h1 class="heading-large">Find your address</h1>
+        <label class="form-label" for="postcode">Postcode</label>
+        <input class="form-control form-control-1-3" type="text" name="postcode" value=""><br><br>
+        <label class="form-label" for="postcode">House name or number (optional)</label>
+        <input class="form-control" type="text" name="postcode" value=""><br><br>
+        <input type="submit" class="button" value="Find your address">
+    </div>
+<% end %>
 
-Here’s an example:
+## When to use this pattern
 
-![Image of a free text address box](Address_1.png)
+Use an address lookup when you’re asking users for a UK address. 
+## When not to use this pattern
 
+Address lookups generally only work for UK addresses. If you’re collecting only or mostly international addresses, you should use a manual option (either multiple fields or a free text box) instead.
+How it works
 
-### Advantages of a free text box
+An address lookup lets users specify a UK address by entering their postcode (and optionally their street name or number) and selecting their address from a list.
 
-A free text box:
+### When using an address lookup, you should:
 
-- can handle any possible address format
-- allows users to copy and paste addresses from their clipboard
-- means users don’t have to work out which part of the address goes in which field
+- make it clear that it will only work for UK addresses
+- provide a manual option for people with international addresses or addresses that are missing or not properly listed in the address lookup
+- let people enter their postcodes in upper or lower case and with or without spaces
 
-### Disadvantages of a free text box
+## Why this pattern is different from the GOV.UK pattern
 
-A free text box:
-
-- makes it hard for you to separate an address into sub-parts, and impossible to do with 100% accuracy
-- might not be compatible with legacy backend systems that use multi-field addresses
-- can’t help users look up an address
-
-
-## Using multiple fields
-
-Only use multiple address fields when you know which regions the addresses will come from and can find a format that supports them all. This can be difficult to know if you’re asking for addresses outside the UK.
-
-
-### Example of multiple fields
-
-Here’s an example of a multiple address field pattern that works for simple UK addresses:
-
-![Image of a multiple-field address box](Address_2.png)
+This address lookup more closley matches the current back end database structure that HMRC have. Since introducing this pattern HMRC have been able to increase the quality of addresses captured.
 
 
-### Advantages of multiple fields
 
-Multiple fields mean:
-
-- you can easily extract and use specific parts of an address (for example, street names or postcodes)
-- you can give help for individual fields
-- you can validate each part of the address separately
-- users can complete the form using their browser’s auto-complete function
-
-
-### Disadvantages of multiple fields
-
-Multiple fields have these disadvantages:
-
-- it’s hard to find a single format that works for all addresses
-- there’s no guarantee that users will use the fields the way you think they will
-- users can’t easily paste addresses from their clipboard
-
-
-### If you use multiple fields
-
-When using multiple fields, you should:
-
-- avoid making individual fields mandatory (but warn users if they don’t fill in any fields)
-- make the fields the appropriate length for the content - it helps people understand the form (for example, make postcode fields shorter than street fields)
-- not make fields case sensitive (let people use upper or lower case)
-- write ‘postcode’ as one word
-- let people enter postcodes with or without spaces
-
-Royal Mail doesn’t need a county as long as the town and postcode are included, but you should include a county field so that people who don’t know their postcode can give a valid address.
-
-
-## Using an address finder
-
-An address finder (sometimes called a ‘postcode lookup’) lets users specify a UK address by entering their postcode (and optionally their street name or number) and selecting their address from a list.
-
-
-#### Example of an address finder
-
-Here’s how the Lasting Power of Attorney service used an address finder:
-
-![Image of a free text address box](postcode-lookup.gif)
-
-
-### Advantages of address finders
-
-Using an address finder means that:
-
-- people entering UK addresses don’t have to enter as much information manually
-- there’s less chance of mis-typed UK addresses
-
-
-### If you use an address finder
-
-When using an address finder you should:
-
-- make it clear that the address finder only works for UK addresses
-- provide a manual option for people with international addresses or addresses that are missing or badly formed in the Royal Mail database
 

--- a/source/design-patterns/patterns/components/addresses/index.html.md.erb
+++ b/source/design-patterns/patterns/components/addresses/index.html.md.erb
@@ -1,8 +1,8 @@
 ---
-title:		Addresses
-section:	Components
-status:		Approved
-discuss:	https://designpatterns.hackpad.com/CgrMSGRAhRc
+title:        Addresses
+section:    Components
+status:        Approved
+discuss:    https://designpatterns.hackpad.com/CgrMSGRAhRc
 department: All
 ---
 
@@ -111,3 +111,6 @@ When using an address finder you should:
 - make it clear that the address finder only works for UK addresses
 - provide a manual option for people with international addresses or addresses that are missing or badly formed in the Royal Mail database
 
+### Variants of addess finder
+
+- [HMRC address finder](hmrc_address.html)


### PR DESCRIPTION
## Background

The pull request adds the HMRC variant of the address finder to the current prototype in preparation for user research in Newcastle on the 18/4.

## Changes/additions

- Added a link to the HMRC variant to the GOV.UK address finder page - This may need to be changed once the final content is in the pattern
- removed the pattern from the main navigation by creating an 'HMRC components' section (in the front matter of the page
- added standard content to the pattern
- added a description of why this is a different pattern
- added a note to the top of the pattern explaining that it's an HMRC pattern